### PR TITLE
Removed missing ref to applicationinsights.config

### DIFF
--- a/src/QuizApp/Quiz.Web/Quiz.Web.csproj
+++ b/src/QuizApp/Quiz.Web/Quiz.Web.csproj
@@ -183,9 +183,6 @@
     <Content Include="Content\Site.css" />
     <Content Include="Scripts\bootstrap.js" />
     <Content Include="Scripts\bootstrap.min.js" />
-    <Content Include="ApplicationInsights.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <Content Include="Areas\Quiz\Views\web.config" />
     <Content Include="Areas\Quiz\Views\ManageQuizItems\Edit.cshtml" />
     <Content Include="Areas\Quiz\Views\ManageQuizItems\Index.cshtml" />


### PR DESCRIPTION
Prosjektfila for QuizApp.Web har ref til applicationinsights.config, men fila mangler i repoet. Vi trenger vel egentlig ikke bruke tid på ApplicationInsights, så jeg foreslår å fjerne den i stedet for å fikse den.